### PR TITLE
Add `null-ls` and `treesitter` to nvim

### DIFF
--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -7,10 +7,6 @@ local set  = vim.opt
 local g    = vim.g
 local map  = vim.keymap.set
 
--- Use Neovim's new Lua-based filetype detection
-g.do_filetype_lua = 1
-g.did_load_filetypes = 0
-
 -- Leader/local leader
 g.mapleader = [[;]]
 g.maplocalleader = [[;]]
@@ -88,7 +84,7 @@ set.mouse        = "a"               -- Enable mouse support
 set.number       = true       -- Show line number
 set.showmatch    = true       -- Show matching braces
 set.list         = true       -- Show invisible characters by default
-set.listchars    = "tab:→ ,eol:¬,trail:⋅,extends:❯,precedes:❮"  -- Show invisible charactes as
+set.listchars    = "tab:→ ,eol:¬,trail:⋅,extends:❯,precedes:❮"  -- Show invisible characters as
 set.showbreak    = "↪"        -- Show newlines as
 
 -- Visuals

--- a/dot_config/nvim/lua/config/lsp.lua
+++ b/dot_config/nvim/lua/config/lsp.lua
@@ -1,0 +1,3 @@
+-- @deprecated: This is taken over by `mypy` over at `null-ls`
+-- Load Pyright for LSP
+-- require("lspconfig").pyright.setup{}

--- a/dot_config/nvim/lua/config/null_ls.lua
+++ b/dot_config/nvim/lua/config/null_ls.lua
@@ -1,0 +1,41 @@
+require("null-ls").setup({
+    sources = {
+        -- General
+        require("null-ls").builtins.diagnostics.codespell.with{
+            -- Disable cluster within the editor itsel
+            diagnostic_config = {
+                virtual_text = false,
+                signs        = false,
+            },
+        },
+
+        -- Python --
+        -- Enable `mypy` integration
+        require("null-ls").builtins.diagnostics.mypy.with{
+            -- Disable cluster within the editor itself
+            diagnostic_config = {
+                virtual_text = false,
+                signs        = false,
+            },
+            extra_args = {
+                "--strict",  -- PACT usually does this
+            },
+            runtime_condition = function(params)
+                -- Do no run mypy in tests.
+                return not params.bufname:match("tests/test_.*%.py")
+            end,
+        },
+
+        -- Enable `flake8`
+        require("null-ls").builtins.diagnostics.flake8.with{
+            -- Disable cluster within the editor itself
+            diagnostic_config = {
+                virtual_text = false,
+                signs        = false,
+            },
+        },
+
+        -- Use `black` as the formatter
+        require("null-ls").builtins.formatting.black,
+    },
+})

--- a/dot_config/nvim/lua/config/treesitter.lua
+++ b/dot_config/nvim/lua/config/treesitter.lua
@@ -1,0 +1,62 @@
+-- nvim-treesitter related configs
+-- Taken from https://github.com/nvim-treesitter/nvim-treesitter#modules
+require'nvim-treesitter.configs'.setup {
+  -- A list of parser names, or "all"
+  ensure_installed = {
+      "bash",
+      "c",
+      "comment",
+      "cpp",
+      "css",
+      "dockerfile",
+      "html",
+      "json",
+      "lua",
+      "make",
+      "markdown",
+      "python",
+      "regex",
+      "rst",
+      "rust",
+      "toml",
+      "typescript",
+      "yaml",
+  },
+
+  -- Install parsers synchronously (only applied to `ensure_installed`)
+  sync_install = false,
+
+  -- Automatically install missing parsers when entering buffer
+  auto_install = true,
+
+  -- List of parsers to ignore installing (for "all")
+  -- ignore_install = { "javascript" },
+
+  ---- If you need to change the installation directory of the parsers (see -> Advanced Setup)
+  -- parser_install_dir = "/some/path/to/store/parsers", -- Remember to run vim.opt.runtimepath:append("/some/path/to/store/parsers")!
+
+  highlight = {
+    -- `false` will disable the whole extension
+    enable = true,
+
+    -- NOTE: these are the names of the parsers and not the filetype. (for example if you want to
+    -- disable highlighting for the `tex` filetype, you need to include `latex` in this list as this is
+    -- the name of the parser)
+    -- list of language that will be disabled
+    disable = {"python"},  -- Disabled until your theme is fixed for treesitter
+    -- Or use a function for more flexibility, e.g. to disable slow treesitter highlight for large files
+    -- disable = function(lang, buf)
+    --     local max_filesize = 100 * 1024 -- 100 KB
+    --     local ok, stats = pcall(vim.loop.fs_stat, vim.api.nvim_buf_get_name(buf))
+    --     if ok and stats and stats.size > max_filesize then
+    --         return true
+    --     end
+    -- end,
+
+    -- Setting this to true will run `:h syntax` and tree-sitter at the same time.
+    -- Set this to `true` if you depend on 'syntax' being enabled (like for indentation).
+    -- Using this option may slow down your editor, and you may see some duplicate highlights.
+    -- Instead of true it can also be a list of languages
+    additional_vim_regex_highlighting = false,
+  },
+}

--- a/dot_config/nvim/lua/plugins.lua
+++ b/dot_config/nvim/lua/plugins.lua
@@ -59,7 +59,11 @@ return require("packer").startup(function()
 
 
     -- Syntax & LSP
-    use "nvim-treesitter/nvim-treesitter"
+    use {
+        "nvim-treesitter/nvim-treesitter",
+        config = [[require "config.treesitter"]],
+        run = function() require('nvim-treesitter.install').update({ with_sync = true }) end,
+    }
     use "neovim/nvim-lspconfig"
     use {
         "jose-elias-alvarez/null-ls.nvim",

--- a/dot_config/nvim/lua/plugins.lua
+++ b/dot_config/nvim/lua/plugins.lua
@@ -39,7 +39,7 @@ return require("packer").startup(function()
 
     use {
         "andymass/vim-matchup",
-        config = [[require("config.matchup")]],
+        config = [[require "config.matchup"]],
     }  -- Better % match up
 
 
@@ -61,6 +61,11 @@ return require("packer").startup(function()
     -- Syntax & LSP
     use "nvim-treesitter/nvim-treesitter"
     use "neovim/nvim-lspconfig"
+    use {
+        "jose-elias-alvarez/null-ls.nvim",
+        config = [[require "config.null_ls"]],
+        requires = { "nvim-lua/plenary.nvim" },
+    }  -- Bridge common tools to LSP
     use "Vimjas/vim-python-pep8-indent"  -- Better indentation for Python
 
 

--- a/dot_config/nvim/lua/provider.lua
+++ b/dot_config/nvim/lua/provider.lua
@@ -1,11 +1,9 @@
--- Load Pyright for LSP
-require("lspconfig").pyright.setup{}
-
 -- Disable error messages display within the buffer
-vim.lsp.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(
-    vim.lsp.diagnostic.on_publish_diagnostics, {
-        virtual_text     = false,
-        update_in_insert = false,
-        signs            = function() end
-    }
-)
+-- @deprecated: This is taken over by `null-ls`.
+-- vim.lsp.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(
+--     vim.lsp.diagnostic.on_publish_diagnostics, {
+--         virtual_text     = false,
+--         update_in_insert = false,
+--         signs            = function() end
+--     }
+-- )


### PR DESCRIPTION
- Fix filetype on Neovim 0.8.0
- Use null-ls; Disable pyright integration
- Use treesitter in Nvim

These changes are made first on your work environment.